### PR TITLE
Refactor code at 1709859117

### DIFF
--- a/books-core/src/main/java/com/sismics/util/jpa/DbOpenHelper.java
+++ b/books-core/src/main/java/com/sismics/util/jpa/DbOpenHelper.java
@@ -26,7 +26,7 @@ public abstract class DbOpenHelper {
         final JdbcServices jdbcServices = serviceRegistry.getService(JdbcServices.class);
         connectionHelper = new SuppliedConnectionProviderConnectionHelper(jdbcServices.getConnectionProvider());
         sqlStatementLogger = jdbcServices.getSqlStatementLogger();
-        formatter = (sqlStatementLogger.isFormat() ? FormatStyle.DDL : FormatStyle.NONE).getFormatter();
+        formatter = sqlStatementLogger.isFormat() ? FormatStyle.DDL.getFormatter() : FormatStyle.NONE.getFormatter();
     }
 
     public void open() {
@@ -52,8 +52,8 @@ public abstract class DbOpenHelper {
     }
 
     private Integer getOldVersion(Connection connection) throws SQLException {
-        try (Statement stmt = connection.createStatement()) {
-            ResultSet result = stmt.executeQuery("select c.CFG_VALUE_C from T_CONFIG c where c.CFG_ID_C='DB_VERSION'");
+        try (Statement statement = connection.createStatement()) {
+            ResultSet result = statement.executeQuery("select c.CFG_VALUE_C from T_CONFIG c where c.CFG_ID_C='DB_VERSION'");
             if (result.next()) {
                 String oldVersionStr = result.getString(1);
                 return Integer.parseInt(oldVersionStr);


### PR DESCRIPTION
The code has been refactored based on smells detected. 
Design smells in temp/books-core/src/main/java/com/sismics/util/jpa/DbOpenHelper.java
Based on the provided Java code and the identified code smells, here is a review of the design smells present in the code:

1. **Cyclomatic Complexity**:
    - The `open()` method has a moderate cyclomatic complexity due to the try-catch block and the logic within it. Consider refactoring this method to reduce complexity by extracting some of the logic into separate methods. For example, extracting the logic related to preparing the connection and getting the old version into separate methods can help reduce the complexity.

2. **Class Data Abstraction Coupling**:
    - The `DbOpenHelper` class is tightly coupled to specific Hibernate and SQL-related classes/interfaces, such as `SuppliedConnectionProviderConnectionHelper`, `FormatStyle`, `SqlStatementLogger`, and `Formatter`. To reduce coupling, consider using interfaces or abstractions for these dependencies. This can help in decoupling the class from specific implementations and improve flexibility.

3. **Class Fan Out Complexity**:
    - The `DbOpenHelper` class has dependencies on multiple external classes, indicating a moderate fan-out complexity. If the number of dependencies grows, it may lead to higher complexity. Consider refactoring the class to reduce the number of dependencies or using dependency injection to manage them more effectively.

4. **Boolean Expression Complexity**:
    - The conditional expression in the constructor `sqlStatementLogger.isFormat() ? FormatStyle.DDL : FormatStyle.NONE` could be simplified for better readability. Breaking it down into smaller, more understandable parts or using a more straightforward approach can improve code clarity.

5. **NPath Complexity**:
    - The `getOldVersion()` method contains nested try-catch blocks, which can increase the NPath complexity. Consider refactoring this method to reduce nesting and improve readability. Breaking down the logic into smaller, more manageable parts can help in reducing complexity.

6. **JavaNCSS**:
    - The `DbOpenHelper` class contains multiple fields and methods, which may increase the JavaNCSS metric. Ensure that each method has a clear and single responsibility to improve maintainability and readability. Consider splitting the class into smaller, more focused classes if it becomes too large and complex.

Overall, while the code is well-structured and follows good practices, there are areas where improvements can be made to address the identified design smells and enhance the code's quality and maintainability.
