### PR TITLE
Refactor code at 1711587178

### DIFF
--- a/books-core/src/main/java/com/sismics/util/jpa/DbOpenHelper.java
+++ b/books-core/src/main/java/com/sismics/util/jpa/DbOpenHelper.java
@@ -20,13 +20,12 @@ public abstract class DbOpenHelper {
     private final SqlStatementLogger sqlStatementLogger;
     private final List<Exception> exceptions = new ArrayList<>();
     private Formatter formatter;
-    private Statement stmt;
 
     public DbOpenHelper(ServiceRegistry serviceRegistry) throws HibernateException {
         final JdbcServices jdbcServices = serviceRegistry.getService(JdbcServices.class);
         connectionHelper = new SuppliedConnectionProviderConnectionHelper(jdbcServices.getConnectionProvider());
         sqlStatementLogger = jdbcServices.getSqlStatementLogger();
-        formatter = (sqlStatementLogger.isFormat() ? FormatStyle.DDL : FormatStyle.NONE).getFormatter();
+        setFormatter();
     }
 
     public void open() {
@@ -38,9 +37,7 @@ public abstract class DbOpenHelper {
         try {
             connectionHelper.prepare(true);
             connection = connectionHelper.getConnection();
-
             Integer oldVersion = getOldVersion(connection);
-
             // Continue with other logic
         } catch (SQLException sqle) {
             exceptions.add(sqle);
@@ -70,5 +67,10 @@ public abstract class DbOpenHelper {
                 log.error("Error closing connection", e);
             }
         }
+    }
+
+    private void setFormatter() {
+        boolean isFormat = sqlStatementLogger.isFormat();
+        formatter = (isFormat ? FormatStyle.DDL : FormatStyle.NONE).getFormatter();
     }
 }


### PR DESCRIPTION
The code has been refactored based on smells detected. 
Design smells in temp/books-core/src/main/java/com/sismics/util/jpa/DbOpenHelper.java
Based on the code provided, here are the design smells identified:

1. **Cyclomatic Complexity**:
   - The `open()` method and the `getOldVersion()` method have moderate cyclomatic complexity due to the try-catch blocks and conditional logic inside them. Consider refactoring these methods to reduce complexity.

2. **Class Data Abstraction Coupling**:
   - The `DbOpenHelper` class is tightly coupled with Hibernate classes like `ServiceRegistry`, `JdbcServices`, and `ConnectionHelper`. Consider abstracting these dependencies to reduce coupling.

3. **Class Fan Out Complexity**:
   - The `DbOpenHelper` class has dependencies on `Logger`, `ConnectionHelper`, `SqlStatementLogger`, and `Formatter`. While some dependencies are necessary, it's important to keep an eye on the number of dependencies a class has.

4. **Boolean Expression Complexity**:
   - The ternary expression in the constructor to set the `formatter` field based on `sqlStatementLogger.isFormat()` could be split into a separate method for better readability.

5. **Error Handling**:
   - The code handles exceptions by adding them to a list in the `exceptions` field. Consider if this is the best approach for error handling and if these exceptions need to be stored in a list.

6. **Resource Management**:
   - The `stmt` field in the class is initialized but never used. Make sure it is not needed or remove it to avoid confusion.

7. **JavaNCSS**:
   - The code could be reviewed for JavaNCSS metrics such as lines of code per method, complexity per method, etc., to ensure it remains maintainable and readable.

Overall, the code could benefit from refactoring to address these design smells and improve maintainability and readability.
